### PR TITLE
LIMS 3635 shorten lookup keyword and add KeyError

### DIFF
--- a/src/senaite/instruments/instruments/bruker/s8tiger/s8tiger.py
+++ b/src/senaite/instruments/instruments/bruker/s8tiger/s8tiger.py
@@ -330,7 +330,7 @@ class S8TigerParser(InstrumentResultsFileParser):
         )
         brains = api.search(query, ANALYSIS_CATALOG)
         analyses = dict((a.getKeyword, a) for a in brains)
-        brains = [v for k, v in analyses.items() if k.startswith(kw)]
+        brains = [v for k, v in analyses.items() if k.startswith(kw[:2])]
         if len(brains) < 1:
             msg = ("No analysis found matching Keyword '${kw}'",)
             raise AnalysisNotFound(msg, kw=kw)
@@ -361,7 +361,7 @@ class S8TigerParser(InstrumentResultsFileParser):
 
     def get_analysis(self, ar, kw):
         analyses = self.get_analyses(ar)
-        analyses = [v for k, v in analyses.items() if k.startswith(kw)]
+        analyses = [v for k, v in analyses.items() if k.startswith(kw[:2])]
         if len(analyses) < 1:
             self.log('No analysis found matching keyword "${kw}"', mapping=dict(kw=kw))
             return None

--- a/src/senaite/instruments/instruments/perkinelmer/nexion350x/nexion350x.py
+++ b/src/senaite/instruments/instruments/perkinelmer/nexion350x/nexion350x.py
@@ -182,7 +182,7 @@ class Nexion350xParser(InstrumentResultsFileParser):
         )
         brains = api.search(query, ANALYSIS_CATALOG)
         analyses = dict((a.getKeyword, a) for a in brains)
-        brains = [v for k, v in analyses.items() if k.startswith(kw)]
+        brains = [v for k, v in analyses.items() if k.startswith(kw[:2])]
         if len(brains) < 1:
             msg = ("No analysis found matching Keyword '${kw}'",)
             raise AnalysisNotFound(msg, kw=kw)
@@ -194,7 +194,7 @@ class Nexion350xParser(InstrumentResultsFileParser):
     def get_reference_sample_analysis(self, reference_sample, kw):
         kw = kw
         brains = self.get_reference_sample_analyses(reference_sample)
-        brains = [v for k, v in brains.items() if k.startswith(kw)]
+        brains = [v for k, v in brains.items() if k.startswith(kw[:2])]
         if len(brains) < 1:
             msg = "No analysis found matching Keyword '${kw}'",
             raise AnalysisNotFound(msg, kw=kw)
@@ -212,7 +212,7 @@ class Nexion350xParser(InstrumentResultsFileParser):
     def get_analysis(self, ar, kw, row_nr="", row=""):
         kw = kw
         items = self.get_analyses(ar)
-        brains = [v for k, v in items.items() if k.startswith(kw)]
+        brains = [v for k, v in items.items() if k.startswith(kw[:2])]
         if len(brains) < 1:
             return None
         if len(brains) > 1:

--- a/src/senaite/instruments/instruments/perkinelmer/winlab32/winlab32.py
+++ b/src/senaite/instruments/instruments/perkinelmer/winlab32/winlab32.py
@@ -104,8 +104,8 @@ class Winlab32(InstrumentResultsFileParser):
         # convert row to use interim field names
         try:
             value = float(row['Conc (Samp)'])
-        except (TypeError, ValueError):
-            value = row['Conc (Samp)']
+        except (TypeError, ValueError, KeyError):
+            value = row.get('Conc (Samp)')
         # reading and Reading - found out users can have Reading or reading
         # when entering interim fields so we cater for both cases
         parsed = {'Reading': value, 'DefaultResult': 'Reading', 'reading': value}
@@ -160,7 +160,7 @@ class Winlab32(InstrumentResultsFileParser):
     def get_analysis(self, ar, kw):
         kw = kw
         brains = self.get_analyses(ar)
-        brains = [v for k, v in brains.items() if k.startswith(kw)]
+        brains = [v for k, v in brains.items() if k.startswith(kw[:2])]
         if len(brains) < 1:
             msg = "No analysis found matching Keyword '${kw}'",
             raise AnalysisNotFound(msg, kw=kw)
@@ -177,7 +177,7 @@ class Winlab32(InstrumentResultsFileParser):
     def get_reference_sample_analysis(self, reference_sample, kw):
         kw = kw
         brains = self.get_reference_sample_analyses(reference_sample)
-        brains = [v for k, v in brains.items() if k.startswith(kw)]
+        brains = [v for k, v in brains.items() if k.startswith(kw[:2])]
         if len(brains) < 1:
             msg = "No analysis found matching Keyword '${kw}'",
             raise AnalysisNotFound(msg, kw=kw)
@@ -209,7 +209,7 @@ class Winlab32(InstrumentResultsFileParser):
         )
         brains = api.search(query, ANALYSIS_CATALOG)
         analyses = dict((a.getKeyword, a) for a in brains)
-        brains = [v for k, v in analyses.items() if k.startswith(kw)]
+        brains = [v for k, v in analyses.items() if k.startswith(kw[:2])]
         if len(brains) < 1:
             msg = ("No analysis found matching Keyword '${kw}'",)
             raise AnalysisNotFound(msg, kw=kw)
@@ -225,7 +225,7 @@ class Winlab32(InstrumentResultsFileParser):
         analyses = dict((a.getKeyword, [a, a.getReferenceAnalysesGroupID]) for a in duplicates)
         brains = []
         for k, v in analyses.items():
-            if k.startswith(kw) and v[1].startswith(analysis_id):
+            if k.startswith(kw[:2]) and v[1].startswith(analysis_id):
                 brains.append(v[0])
         if len(brains) < 1:
             msg = ("No analysis found matching Keyword '${kw}'",)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://jira.bikalabs.com/browse/LIMS-3635

## Current behavior before PR

Full keyword was being used for lookup.

## Desired behavior after PR is merged

First two characters are being used for lookup. Also note that I made very slight changes to the winlab.py file.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
